### PR TITLE
check formatting as well as linting violations in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: pip install ruff
-      - run: ruff check
+      - run: ruff check # check linting violations
+      - run: ruff format --check # check formatting
 
   docs:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,9 @@ repos:
     - repo: https://github.com/charliermarsh/ruff-pre-commit
       rev: v0.5.6
       hooks:
-          - id: ruff
+          - id: ruff # fix linting violations
             args: [ --fix ]
-          - id: ruff-format
+          - id: ruff-format # fix formatting
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:


### PR DESCRIPTION
`ruff check `only checks for linting violations.

This updates ci to also check the code formatting with `ruff format --check`.